### PR TITLE
Changes to accomodate Slack

### DIFF
--- a/scripts/github-pull-requests.coffee
+++ b/scripts/github-pull-requests.coffee
@@ -18,6 +18,7 @@
 #
 # Author:
 #   helious (David Posey)
+#   davedash (Dave Dash)
 
 async = require 'async'
 Promise = require 'bluebird'
@@ -64,7 +65,7 @@ module.exports = (robot) ->
         gitHubRepo
           .prsAsync()
           .then (data) ->
-            postToHipChat = (pr) ->
+            postToChat = (pr) ->
               lastUpdated = (date) ->
                 pluralize = (amount, unit) ->
                   if amount
@@ -91,10 +92,13 @@ module.exports = (robot) ->
               if pr.assignee
                 people = "#{ user }->#{ pr.assignee.login }"
 
-              msg.send "/me - #{ repo } - ##{ number } - #{ title } - #{ people } - #{ url } - #{ lastUpdated updatedAt }"
+              if robot.adapterName == 'slack'
+                msg.send ":octocat: #{ title } - #{ people } - #{ url } - #{ lastUpdated updatedAt }"
+              else
+                msg.send "/me - #{ repo } - ##{ number } - #{ title } - #{ people } - #{ url } - #{ lastUpdated updatedAt }"
             prs = data[0]
 
-            postToHipChat pr for pr in prs
+            postToChat pr for pr in prs
           .then ->
             done null, prs.length
 

--- a/scripts/github-pull-requests.coffee
+++ b/scripts/github-pull-requests.coffee
@@ -86,8 +86,12 @@ module.exports = (robot) ->
               title = pr.title
               updatedAt = pr.updated_at
               user = pr.user.login
+              people = user
 
-              msg.send "/me - #{ repo } - ##{ number } - #{ title } - #{ user } - #{ url } - #{ lastUpdated updatedAt }"
+              if pr.assignee
+                people = "#{ user }->#{ pr.assignee.login }"
+
+              msg.send "/me - #{ repo } - ##{ number } - #{ title } - #{ people } - #{ url } - #{ lastUpdated updatedAt }"
             prs = data[0]
 
             postToHipChat pr for pr in prs


### PR DESCRIPTION
- I added myself as an author ;)
- Changed the method to postToChat since we can do more than HipChat
- Used a different message format for Slack
  - It uses the :octocat: 
  - It doesn't use `/me` because that gets transmitted literally into Slack
  - It removes the PR number and other metadata which is repeated in the URL

I verified that the previous method still works.  I did build this off my previous PR, so feel free to review that first.
